### PR TITLE
Make MaxChanLen a per Conn option

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -35,6 +35,7 @@ const (
 	DefaultTimeout       = 2 * time.Second
 	DefaultPingInterval  = 2 * time.Minute
 	DefaultMaxPingOut    = 2
+	DefaultMaxChanLen    = 65536
 )
 
 // For detection and proper handling of a Stale Connection
@@ -63,6 +64,9 @@ var DefaultOptions = Options{
 
 	PingInterval: DefaultPingInterval,
 	MaxPingsOut:  DefaultMaxPingOut,
+	// The size of the buffered channel used between the socket
+	// Go routine and the message delivery or sync subscription.
+	MaxChanLen: DefaultMaxChanLen,
 }
 
 type Status int
@@ -102,13 +106,10 @@ type Options struct {
 
 	PingInterval time.Duration // disabled if 0 or negative
 	MaxPingsOut  int
+	MaxChanLen     int
 }
 
 const (
-	// The size of the buffered channel used between the socket
-	// Go routine and the message delivery or sync subscription.
-	maxChanLen = 65536
-
 	// Scratch storage for assembling protocol headers
 	scratchSize = 512
 
@@ -1018,7 +1019,7 @@ func (nc *Conn) processMsg(msg []byte) {
 	m := &Msg{Data: newMsg, Subject: subj, Reply: reply, Sub: sub}
 
 	if sub.mch != nil {
-		if len(sub.mch) >= maxChanLen {
+		if len(sub.mch) >= nc.Opts.MaxChanLen {
 			nc.processSlowConsumer(sub)
 		} else {
 			// Clear always
@@ -1262,7 +1263,7 @@ func (nc *Conn) subscribe(subj, queue string, cb MsgHandler) (*Subscription, err
 	}
 
 	sub := &Subscription{Subject: subj, Queue: queue, mcb: cb, conn: nc}
-	sub.mch = make(chan *Msg, maxChanLen)
+	sub.mch = make(chan *Msg, nc.Opts.MaxChanLen)
 
 	// If we have an async callback, start up a sub specific
 	// Go routine to deliver the messages.

--- a/sub_test.go
+++ b/sub_test.go
@@ -123,7 +123,7 @@ func TestSlowSubscriber(t *testing.T) {
 	defer nc.Close()
 
 	sub, _ := nc.SubscribeSync("foo")
-	for i := 0; i < (maxChanLen + 100); i++ {
+	for i := 0; i < (DefaultMaxChanLen + 100); i++ {
 		nc.Publish("foo", []byte("Hello"))
 	}
 	timeout := 5 * time.Second
@@ -147,7 +147,7 @@ func TestSlowAsyncSubscriber(t *testing.T) {
 	nc.Subscribe("foo", func(_ *Msg) {
 		time.Sleep(200 * time.Second)
 	})
-	for i := 0; i < (maxChanLen + 100); i++ {
+	for i := 0; i < (DefaultMaxChanLen + 100); i++ {
 		nc.Publish("foo", []byte("Hello"))
 	}
 	timeout := 5 * time.Second
@@ -187,7 +187,7 @@ func TestAsyncErrHandler(t *testing.T) {
 	}
 
 	b := []byte("Hello World!")
-	for i := 0; i < (maxChanLen + 100); i++ {
+	for i := 0; i < (DefaultMaxChanLen + 100); i++ {
 		nc.Publish(subj, b)
 	}
 


### PR DESCRIPTION
Our particular use case uses many low throughput subscriptions. The default channel length of 64k uses quite a lot of memory and isn't necessary for us.

This PR adds the ability to override `MaxChanLen`