### PR TITLE
fix mrand not init properly

### DIFF
--- a/nats.go
+++ b/nats.go
@@ -371,11 +371,13 @@ func (nc *Conn) setupServerPool() error {
 	}
 
 	var srvrs []string
+	source := mrand.NewSource(time.Now().UnixNano())
+	r := mrand.New(source)
 
 	if nc.Opts.NoRandomize {
 		srvrs = nc.Opts.Servers
 	} else {
-		in := mrand.Perm(len(nc.Opts.Servers))
+		in := r.Perm(len(nc.Opts.Servers))
 		for _, i := range in {
 			srvrs = append(srvrs, nc.Opts.Servers[i])
 		}


### PR DESCRIPTION
Order of nc.Opts.Servers would remain the same if use math.rand without a seed,
so use time.UnixNano() as seed to init it.